### PR TITLE
Feature: Add partner to interview and replace a partner

### DIFF
--- a/src/main/java/com/janurb/awesomeinterviewmanager/interview/Interview.java
+++ b/src/main/java/com/janurb/awesomeinterviewmanager/interview/Interview.java
@@ -10,6 +10,14 @@ public class Interview {
     private LocalDateTime start;
     private Integer durationInMinutes;
 
+    public Interview(UUID uuid, String interviewPartner, String candidate, LocalDateTime start, Integer durationInMinutes) {
+        this.uuid = uuid;
+        this.interviewPartner = interviewPartner;
+        this.candidate = candidate;
+        this.start = start;
+        this.durationInMinutes = durationInMinutes;
+    }
+
     public UUID getUuid() {
         return uuid;
     }
@@ -30,11 +38,23 @@ public class Interview {
         return durationInMinutes;
     }
 
-    public Interview(UUID uuid, String interviewPartner, String candidate, LocalDateTime start, Integer durationInMinutes) {
+    public void setUuid(UUID uuid) {
         this.uuid = uuid;
+    }
+
+    public void setInterviewPartner(String interviewPartner) {
         this.interviewPartner = interviewPartner;
+    }
+
+    public void setCandidate(String candidate) {
         this.candidate = candidate;
+    }
+
+    public void setStart(LocalDateTime start) {
         this.start = start;
+    }
+
+    public void setDurationInMinutes(Integer durationInMinutes) {
         this.durationInMinutes = durationInMinutes;
     }
 }

--- a/src/main/java/com/janurb/awesomeinterviewmanager/interview/InterviewController.java
+++ b/src/main/java/com/janurb/awesomeinterviewmanager/interview/InterviewController.java
@@ -1,7 +1,6 @@
 package com.janurb.awesomeinterviewmanager.interview;
 
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -24,5 +23,13 @@ public class InterviewController {
         return interviewHandler.loadInterviewsFromToday();
     }
 
+    @PutMapping("/{id}/partner")
+    public Interview addPartner(@PathVariable("id") String interviewId, @RequestParam("partner") String partner) {
+        return interviewHandler.addPartner(interviewId, partner);
+    }
 
+    @PostMapping("/massreplacement")
+    public List<Interview> replaceAll(@RequestParam("currentPartner") String currentPartner, @RequestParam("replacement") String replacement) {
+        return interviewHandler.replacePartner(currentPartner, replacement);
+    }
 }

--- a/src/main/java/com/janurb/awesomeinterviewmanager/interview/InterviewHandler.java
+++ b/src/main/java/com/janurb/awesomeinterviewmanager/interview/InterviewHandler.java
@@ -1,20 +1,24 @@
 package com.janurb.awesomeinterviewmanager.interview;
 
+import com.janurb.awesomeinterviewmanager.services.InterviewService;
 import com.janurb.awesomeinterviewmanager.storage.DatabaseAdapter;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Service
 public class InterviewHandler {
 
     private final DatabaseAdapter database;
+    private final InterviewService interviewService;
 
-    public InterviewHandler(DatabaseAdapter database) {
+    public InterviewHandler(DatabaseAdapter database, InterviewService interviewService) {
         this.database = database;
+        this.interviewService = interviewService;
     }
 
 
@@ -30,4 +34,11 @@ public class InterviewHandler {
             .collect(Collectors.toList());
     }
 
+    public Interview addPartner(String id, String partner) {
+        return interviewService.addPartner(UUID.fromString(id), partner).orElse(null);
+    }
+
+    public List<Interview> replacePartner(String currentPartner, String replacement) {
+        return interviewService.replacePartner(currentPartner, replacement);
+    }
 }

--- a/src/main/java/com/janurb/awesomeinterviewmanager/services/InterviewService.java
+++ b/src/main/java/com/janurb/awesomeinterviewmanager/services/InterviewService.java
@@ -1,0 +1,73 @@
+package com.janurb.awesomeinterviewmanager.services;
+
+import com.janurb.awesomeinterviewmanager.interview.Interview;
+import com.janurb.awesomeinterviewmanager.storage.DatabaseAdapter;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static java.util.List.of;
+
+@Service
+public class InterviewService {
+
+    private final DatabaseAdapter database;
+
+
+    public InterviewService(DatabaseAdapter database) {
+        this.database = database;
+    }
+
+    public Optional<Interview> addPartner(UUID interviewId, String partner) {
+        var interviewOpt = database.findById(interviewId);
+        if (interviewOpt.isPresent()) {
+            var interview = interviewOpt.get();
+
+            if (interviewIsExpired(interview)) {
+                return Optional.empty();
+            }
+
+            interview.setInterviewPartner(partner);
+            var storedInterview = database.save(interview);
+            return Optional.of(storedInterview);
+        }
+        return Optional.empty();
+    }
+
+    public List<Interview> replacePartner(String currentPartner, String replacement) {
+        if (currentPartner.equals(replacement)) {
+            return of();
+        }
+
+        var interviews = database.findAll();
+        var filteredInterviews = new ArrayList<Interview>();
+
+        for (var interview : interviews) {
+            if (interviewIsExpired(interview)) {
+                continue;
+            }
+            if (interview.getInterviewPartner().equals(currentPartner)) {
+                filteredInterviews.add(interview);
+            }
+        }
+
+        var storedInterviews = new ArrayList<Interview>();
+
+        for (var filteredInterview : filteredInterviews) {
+            filteredInterview.setInterviewPartner(replacement);
+            var stored = database.save(filteredInterview);
+            storedInterviews.add(stored);
+        }
+
+        return storedInterviews;
+    }
+
+    private boolean interviewIsExpired(Interview interview) {
+        var isExpired = interview.getStart().toLocalDate().isBefore(LocalDate.now());
+        return isExpired;
+    }
+}

--- a/src/main/java/com/janurb/awesomeinterviewmanager/storage/DatabaseAdapter.java
+++ b/src/main/java/com/janurb/awesomeinterviewmanager/storage/DatabaseAdapter.java
@@ -22,7 +22,12 @@ public class DatabaseAdapter implements InterviewStorage {
     }
 
     @Override
-    public Optional<Interview> findById() {
-        return Optional.empty();
+    public Optional<Interview> findById(UUID id) {
+        return interviews.stream().filter(interview -> id.equals(interview.getUuid())).findFirst();
+    }
+
+    @Override
+    public Interview save(Interview interview) {
+        return interview;
     }
 }

--- a/src/main/java/com/janurb/awesomeinterviewmanager/storage/InterviewStorage.java
+++ b/src/main/java/com/janurb/awesomeinterviewmanager/storage/InterviewStorage.java
@@ -4,11 +4,14 @@ import com.janurb.awesomeinterviewmanager.interview.Interview;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 public interface InterviewStorage {
 
     List<Interview> findAll();
 
-    Optional<Interview> findById();
+    Optional<Interview> findById(UUID id);
+
+    Interview save(Interview interview);
 
 }

--- a/src/test/java/com/janurb/awesomeinterviewmanager/interview/InterviewHandlerTest.java
+++ b/src/test/java/com/janurb/awesomeinterviewmanager/interview/InterviewHandlerTest.java
@@ -21,7 +21,7 @@ class InterviewHandlerTest {
         var uuid = UUID.randomUUID();
         List<Interview> expected = List.of(new Interview(uuid, null, null, null, null));
         when(dbMock.findAll()).thenReturn(expected);
-        var sut = new InterviewHandler(dbMock);
+        var sut = new InterviewHandler(dbMock, null);
 
         var actual = sut.loadAllInterviews();
 
@@ -34,7 +34,7 @@ class InterviewHandlerTest {
         var uuid = UUID.randomUUID();
         List<Interview> expected = List.of(new Interview(uuid, null, null, LocalDateTime.now(), null));
         when(dbMock.findAll()).thenReturn(expected);
-        var sut = new InterviewHandler(dbMock);
+        var sut = new InterviewHandler(dbMock, null);
 
         var actual = sut.loadInterviewsFromToday();
 
@@ -46,7 +46,7 @@ class InterviewHandlerTest {
         var dbMock = mock(DatabaseAdapter.class);
         var uuid = UUID.randomUUID();
         when(dbMock.findAll()).thenReturn(List.of(new Interview(uuid, null, null, null, null)));
-        var sut = new InterviewHandler(dbMock);
+        var sut = new InterviewHandler(dbMock, null);
 
         var actual = sut.loadInterviewsFromToday();
 

--- a/src/test/java/com/janurb/awesomeinterviewmanager/services/InterviewServiceTest.java
+++ b/src/test/java/com/janurb/awesomeinterviewmanager/services/InterviewServiceTest.java
@@ -1,0 +1,49 @@
+package com.janurb.awesomeinterviewmanager.services;
+
+import com.janurb.awesomeinterviewmanager.interview.Interview;
+import com.janurb.awesomeinterviewmanager.storage.DatabaseAdapter;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.AdditionalAnswers.returnsFirstArg;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class InterviewServiceTest {
+
+
+    @Test
+    void adds_a_partner() {
+        var dbMock = mock(DatabaseAdapter.class);
+        var uuid = UUID.randomUUID();
+        when(dbMock.findById(uuid)).thenReturn(Optional.of(new Interview(uuid, null, null, LocalDateTime.now(), null)));
+        when(dbMock.save(any())).thenAnswer(returnsFirstArg());
+        var sut = new InterviewService(dbMock);
+
+        var actual = sut.addPartner(uuid, "Jan");
+
+        assertThat(actual).isPresent();
+        assertThat(actual.get().getInterviewPartner()).isEqualTo("Jan");
+    }
+
+    @Test
+    void replaces_a_partner() {
+        var dbMock = mock(DatabaseAdapter.class);
+        var uuid = UUID.randomUUID();
+        when(dbMock.findAll()).thenReturn(List.of(new Interview(uuid, "Jan", null, LocalDateTime.now(), null)));
+        when(dbMock.save(any())).thenAnswer(returnsFirstArg());
+        var sut = new InterviewService(dbMock);
+
+        var actual = sut.replacePartner("Jan", "Maik");
+
+        assertThat(actual).hasSize(1);
+        assertThat(actual.get(0).getInterviewPartner()).isEqualTo("Maik");
+    }
+
+}


### PR DESCRIPTION
This commit adds the functionality to add an interview partner to a specific interview.
Additionally, a partner can now be replaced on all interviews.